### PR TITLE
Add React WebRTC room demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# WebRTC
+# React WebRTC Rooms
+
+This project provides a minimal WebRTC demo that lets two people create and join ad-hoc video rooms using a short code. It contains:
+
+- A lightweight signaling server implemented in Node.js without third-party dependencies
+- A React front-end (delivered via CDN) that handles room creation/joining and WebRTC peer connections
+
+## Getting started
+
+1. **Install Node.js** (version 18 or later recommended).
+2. **Start the server:**
+
+   ```bash
+   npm start
+   ```
+
+   The server runs on [http://localhost:3000](http://localhost:3000) by default.
+
+3. **Open the app** in your browser and allow camera/microphone access when prompted.
+4. One participant clicks **Create Room** to receive a code and shares it with the other person.
+5. The second participant enters the shared code and clicks **Join Room**.
+6. Once both are connected, a peer-to-peer WebRTC video call is established.
+
+> **Note:** The front-end uses CDN bundles for React and Babel to avoid build tooling, so an internet connection is required when loading the page.
+
+## How it works
+
+- The Node.js server serves static assets from the `public` directory and performs the WebSocket signaling handshake.
+- Room membership and signaling messages (offer, answer, ICE candidates) are relayed through the WebSocket connection.
+- A maximum of two participants can occupy a room simultaneously. If one participant leaves, the remaining user becomes the host and can accept a new peer using the same code.
+
+## Project structure
+
+```
+├── package.json
+├── public
+│   ├── app.jsx
+│   ├── index.html
+│   └── styles.css
+└── server.js
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "webrtc-react-room",
+  "version": "1.0.0",
+  "description": "React-based WebRTC demo with manual signaling server.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "webrtc",
+    "react",
+    "signaling"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -1,0 +1,418 @@
+const { useEffect, useRef, useState } = React;
+
+function App() {
+  const [roomCode, setRoomCode] = useState('');
+  const [roomInput, setRoomInput] = useState('');
+  const [status, setStatus] = useState('Create a room or join with a shared code to start a call.');
+  const [error, setError] = useState('');
+  const [connected, setConnected] = useState(false);
+  const [isHost, setIsHost] = useState(false);
+
+  const localVideoRef = useRef(null);
+  const remoteVideoRef = useRef(null);
+  const wsRef = useRef(null);
+  const pcRef = useRef(null);
+  const localStreamRef = useRef(null);
+  const pendingCandidatesRef = useRef([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function initMedia() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        if (!cancelled) {
+          localStreamRef.current = stream;
+          if (localVideoRef.current) {
+            localVideoRef.current.srcObject = stream;
+          }
+        }
+      } catch (err) {
+        console.error('Media error', err);
+        setError('Unable to access camera or microphone. Please ensure permissions are granted.');
+        setStatus('Camera or microphone permission is required for the call.');
+      }
+    }
+
+    initMedia();
+
+    return () => {
+      cancelled = true;
+      if (localStreamRef.current) {
+        localStreamRef.current.getTracks().forEach((track) => track.stop());
+        localStreamRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && roomCode) {
+        wsRef.current.send(JSON.stringify({ type: 'leave' }));
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [roomCode]);
+
+  function setupSocket(onOpen) {
+    const existing = wsRef.current;
+    if (existing && (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)) {
+      if (onOpen) {
+        if (existing.readyState === WebSocket.OPEN) {
+          onOpen(existing);
+        } else {
+          existing.addEventListener('open', () => onOpen(existing), { once: true });
+        }
+      }
+      return existing;
+    }
+
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const socket = new WebSocket(`${protocol}://${window.location.host}/ws`);
+    wsRef.current = socket;
+
+    socket.addEventListener('open', () => {
+      setStatus('Connected to signaling server.');
+      if (onOpen) {
+        onOpen(socket);
+      }
+    });
+
+    socket.addEventListener('message', (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        handleSignal(payload);
+      } catch (err) {
+        console.error('Failed to parse message', err);
+      }
+    });
+
+    socket.addEventListener('close', () => {
+      setStatus('Disconnected from signaling server.');
+      setConnected(false);
+      cleanupPeer();
+      setRoomCode('');
+      setIsHost(false);
+    });
+
+    socket.addEventListener('error', () => {
+      setError('A signaling connection error occurred.');
+    });
+
+    return socket;
+  }
+
+  function sendSignal(message) {
+    const socket = setupSocket();
+    const payload = JSON.stringify(message);
+
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(payload);
+    } else if (socket.readyState === WebSocket.CONNECTING) {
+      socket.addEventListener('open', () => socket.send(payload), { once: true });
+    }
+  }
+
+  function getPeerConnection() {
+    if (pcRef.current) {
+      return pcRef.current;
+    }
+
+    const pc = new RTCPeerConnection({
+      iceServers: [
+        { urls: 'stun:stun.l.google.com:19302' },
+        { urls: 'stun:stun1.l.google.com:19302' },
+        { urls: 'stun:stun2.l.google.com:19302' }
+      ]
+    });
+
+    pcRef.current = pc;
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        sendSignal({ type: 'candidate', candidate: event.candidate });
+      }
+    };
+
+    pc.ontrack = (event) => {
+      const [stream] = event.streams;
+      if (remoteVideoRef.current) {
+        remoteVideoRef.current.srcObject = stream;
+      }
+    };
+
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'connected') {
+        setConnected(true);
+        setStatus('Connected to peer.');
+      } else if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        setConnected(false);
+        setStatus(`Connection state: ${pc.connectionState}. Attempting to recover...`);
+      }
+    };
+
+    const localStream = localStreamRef.current;
+    if (localStream) {
+      localStream.getTracks().forEach((track) => pc.addTrack(track, localStream));
+    }
+
+    return pc;
+  }
+
+  async function startOffer() {
+    try {
+      const pc = getPeerConnection();
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      sendSignal({ type: 'offer', offer });
+      setStatus('Sending offer to peer...');
+    } catch (err) {
+      console.error('Failed to create offer', err);
+      setError('Unable to start the WebRTC offer.');
+    }
+  }
+
+  async function handleOffer(offer) {
+    try {
+      const pc = getPeerConnection();
+      await pc.setRemoteDescription(new RTCSessionDescription(offer));
+      await flushPendingCandidates();
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      sendSignal({ type: 'answer', answer });
+      setStatus('Offer received. Answer sent.');
+    } catch (err) {
+      console.error('Error handling offer', err);
+      setError('Could not process the incoming offer.');
+    }
+  }
+
+  async function handleAnswer(answer) {
+    try {
+      const pc = getPeerConnection();
+      await pc.setRemoteDescription(new RTCSessionDescription(answer));
+      await flushPendingCandidates();
+      setStatus('Answer received. Finalizing connection...');
+    } catch (err) {
+      console.error('Error handling answer', err);
+      setError('Could not apply the remote answer.');
+    }
+  }
+
+  function handleCandidate(candidate) {
+    const rtcCandidate = new RTCIceCandidate(candidate);
+    if (pcRef.current && pcRef.current.remoteDescription) {
+      pcRef.current.addIceCandidate(rtcCandidate).catch((err) => {
+        console.error('Error adding candidate', err);
+      });
+    } else {
+      pendingCandidatesRef.current.push(rtcCandidate);
+    }
+  }
+
+  async function flushPendingCandidates() {
+    const pc = pcRef.current;
+    if (!pc || !pc.remoteDescription) {
+      return;
+    }
+
+    while (pendingCandidatesRef.current.length > 0) {
+      const candidate = pendingCandidatesRef.current.shift();
+      try {
+        await pc.addIceCandidate(candidate);
+      } catch (err) {
+        console.error('Error flushing candidate', err);
+      }
+    }
+  }
+
+  function cleanupPeer() {
+    if (pcRef.current) {
+      try {
+        pcRef.current.ontrack = null;
+        pcRef.current.onicecandidate = null;
+        pcRef.current.onconnectionstatechange = null;
+        pcRef.current.close();
+      } catch (err) {
+        console.error('Error closing peer connection', err);
+      }
+      pcRef.current = null;
+    }
+    pendingCandidatesRef.current = [];
+    if (remoteVideoRef.current) {
+      remoteVideoRef.current.srcObject = null;
+    }
+  }
+
+  function handleSignal(message) {
+    switch (message.type) {
+      case 'created':
+        setRoomCode(message.roomId);
+        setIsHost(true);
+        setError('');
+        setStatus(`Room ${message.roomId} created. Share the code with a friend.`);
+        setRoomInput('');
+        break;
+      case 'joined':
+        setRoomCode(message.roomId);
+        setIsHost(false);
+        setError('');
+        setStatus(`Joined room ${message.roomId}. Waiting for the call to start...`);
+        setRoomInput('');
+        break;
+      case 'ready':
+        setStatus('Peer joined! Establishing connection...');
+        if (message.initiator) {
+          startOffer();
+        } else {
+          getPeerConnection();
+        }
+        break;
+      case 'offer':
+        handleOffer(message.offer);
+        break;
+      case 'answer':
+        handleAnswer(message.answer);
+        break;
+      case 'candidate':
+        handleCandidate(message.candidate);
+        break;
+      case 'peer-left':
+        setConnected(false);
+        cleanupPeer();
+        if (remoteVideoRef.current) {
+          remoteVideoRef.current.srcObject = null;
+        }
+        if (typeof message.isHost === 'boolean') {
+          setIsHost(message.isHost);
+        }
+        setStatus(message.isHost ? 'Peer left the room. Waiting for someone new to join.' : 'Peer left the room.');
+        break;
+      case 'error':
+        setError(message.message || 'An unknown error occurred.');
+        setStatus(`Error: ${message.message}`);
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleCreateRoom() {
+    setError('');
+    const desiredCode = generateRoomCode();
+    setStatus('Creating room...');
+    setupSocket((socket) => {
+      socket.send(JSON.stringify({ type: 'create', roomId: desiredCode }));
+    });
+  }
+
+  function handleJoinRoom() {
+    const code = roomInput.trim().toUpperCase();
+    if (!code) {
+      setError('Enter a room code to join.');
+      return;
+    }
+    setError('');
+    setStatus(`Joining room ${code}...`);
+    setupSocket((socket) => {
+      socket.send(JSON.stringify({ type: 'join', roomId: code }));
+    });
+  }
+
+  function handleLeaveRoom() {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'leave' }));
+    }
+    cleanupPeer();
+    setConnected(false);
+    setRoomCode('');
+    setIsHost(false);
+    setStatus('Left the room. Create a new one or join with a code.');
+  }
+
+  async function handleCopyCode() {
+    if (!roomCode || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(roomCode);
+      setStatus('Room code copied to clipboard!');
+    } catch (err) {
+      console.error('Copy failed', err);
+      setError('Unable to copy the room code. Copy it manually.');
+    }
+  }
+
+  function generateRoomCode() {
+    return Math.random().toString(36).slice(2, 8).toUpperCase();
+  }
+
+  return (
+    <div className="container">
+      <h1>React WebRTC Rooms</h1>
+      <div className="controls">
+        <div className="control-card">
+          <h2>Create a room</h2>
+          <p>Generate a private code and share it with a friend to start a secure peer-to-peer call.</p>
+          <button type="button" onClick={handleCreateRoom} disabled={Boolean(roomCode)}>
+            {roomCode ? 'Room Active' : 'Create Room'}
+          </button>
+          {roomCode && (
+            <p className="room-code">
+              Code: <span>{roomCode}</span>
+              <button type="button" onClick={handleCopyCode}>Copy</button>
+            </p>
+          )}
+        </div>
+
+        <div className="control-card">
+          <h2>Join a room</h2>
+          <p>Enter the room code shared with you to join the conversation.</p>
+          <input
+            type="text"
+            value={roomInput}
+            onChange={(event) => setRoomInput(event.target.value.toUpperCase())}
+            placeholder="Enter room code"
+            maxLength={8}
+            disabled={Boolean(roomCode)}
+          />
+          <button type="button" onClick={handleJoinRoom} disabled={Boolean(roomCode)}>
+            Join Room
+          </button>
+        </div>
+
+        <div className="control-card status">
+          <h2>Status</h2>
+          <p>{status}</p>
+          {error && <p className="error">{error}</p>}
+          {roomCode && (
+            <>
+              <p className="role-indicator">You are the {isHost ? 'host' : 'guest'} of this room.</p>
+              <button type="button" onClick={handleLeaveRoom}>
+                Leave Room
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="videos">
+        <div className="video-wrapper">
+          <h3>Your preview</h3>
+          <video ref={localVideoRef} autoPlay playsInline muted></video>
+        </div>
+        <div className="video-wrapper">
+          <h3>Remote participant</h3>
+          <video ref={remoteVideoRef} autoPlay playsInline></video>
+        </div>
+      </div>
+
+      {connected && <div className="connected">You are now on a call.</div>}
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <div id="root"></div>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script type="text/babel" data-presets="env,react" src="/app.jsx"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>React WebRTC Rooms</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script type="text/babel" data-presets="env,react" src="/app.jsx"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,194 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #101418;
+  color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(160deg, #0f172a, #1e293b 45%, #020617 100%);
+}
+
+.container {
+  max-width: 960px;
+  width: 100%;
+  padding: 2rem;
+  box-sizing: border-box;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  box-shadow: 0 20px 60px rgba(2, 6, 23, 0.6);
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 2.25rem;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+p {
+  line-height: 1.6;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.control-card {
+  padding: 1.5rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+
+.control-card h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+.control-card button,
+.control-card input {
+  width: 100%;
+  border-radius: 10px;
+  border: none;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.control-card button {
+  margin-top: 0.5rem;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+}
+
+.control-card button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.35);
+}
+
+.control-card button:active {
+  transform: translateY(0);
+}
+
+.control-card input {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.control-card input::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.status {
+  grid-column: 1 / -1;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.15);
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  font-weight: 500;
+}
+
+.role-indicator {
+  margin: 0.75rem 0 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.95rem;
+}
+
+.status .error {
+  grid-column: 1 / -1;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.2);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+}
+
+.control-card.status button {
+  margin-top: 1rem;
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  box-shadow: 0 10px 25px rgba(249, 115, 22, 0.25);
+}
+
+.control-card.status button:hover {
+  box-shadow: 0 12px 28px rgba(249, 115, 22, 0.32);
+}
+
+.room-code {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+}
+
+.room-code button {
+  width: auto;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+  box-shadow: none;
+}
+
+.videos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.video-wrapper {
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.video-wrapper h3 {
+  margin: 0 0 0.75rem;
+}
+
+video {
+  width: 100%;
+  height: 240px;
+  background: #0f172a;
+  border-radius: 12px;
+  object-fit: cover;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.connected {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  font-weight: 600;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 1.5rem;
+  }
+
+  video {
+    height: 200px;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,344 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+const clients = new Map();
+const rooms = new Map();
+let clientCounter = 1;
+
+const server = http.createServer((req, res) => {
+  const [rawPath] = req.url.split('?');
+  const requestPath = rawPath === '/' ? 'index.html' : decodeURIComponent(rawPath.replace(/^\/+/, ''));
+  const safePath = path.normalize(requestPath).replace(/^([.]{2}[\/])+/g, '');
+  const filePath = path.join(PUBLIC_DIR, safePath);
+
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(err.code === 'ENOENT' ? 404 : 500);
+      res.end('Not Found');
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const type = getContentType(ext);
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+server.on('upgrade', (req, socket) => {
+  if (req.headers['upgrade'] !== 'websocket') {
+    socket.end('HTTP/1.1 400 Bad Request');
+    return;
+  }
+
+  if (req.url !== '/ws') {
+    socket.end('HTTP/1.1 404 Not Found');
+    return;
+  }
+
+  const acceptKey = generateAcceptValue(req.headers['sec-websocket-key']);
+  const responseHeaders = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${acceptKey}`
+  ];
+
+  socket.write(responseHeaders.join('\r\n') + '\r\n\r\n');
+
+  const clientId = clientCounter++;
+  const client = {
+    id: clientId,
+    socket,
+    buffer: Buffer.alloc(0),
+    roomId: null,
+    isHost: false
+  };
+
+  clients.set(socket, client);
+
+  socket.on('data', (chunk) => {
+    client.buffer = Buffer.concat([client.buffer, chunk]);
+    let result;
+    do {
+      result = decodeFrame(client.buffer);
+      if (result) {
+        client.buffer = client.buffer.slice(result.length);
+        if (result.opcode === 0x8) {
+          socket.end();
+          return;
+        }
+
+        try {
+          const text = result.payload.toString('utf8');
+          const message = JSON.parse(text);
+          handleMessage(client, message);
+        } catch (err) {
+          send(client, { type: 'error', message: 'Invalid message format.' });
+        }
+      }
+    } while (result);
+  });
+
+  socket.on('close', () => {
+    cleanupClient(client);
+    clients.delete(socket);
+  });
+
+  socket.on('end', () => {
+    cleanupClient(client);
+    clients.delete(socket);
+  });
+
+  socket.on('error', () => {
+    cleanupClient(client);
+    clients.delete(socket);
+  });
+});
+
+function handleMessage(client, message) {
+  switch (message.type) {
+    case 'create':
+      return handleCreateRoom(client, message.roomId);
+    case 'join':
+      return handleJoinRoom(client, message.roomId);
+    case 'offer':
+    case 'answer':
+    case 'candidate':
+      return forwardToRoom(client, message);
+    case 'leave':
+      return cleanupClient(client);
+    default:
+      send(client, { type: 'error', message: 'Unknown message type.' });
+  }
+}
+
+function handleCreateRoom(client, requestedRoomId) {
+  const roomId = (requestedRoomId || generateRoomCode()).toUpperCase();
+  if (rooms.has(roomId)) {
+    send(client, { type: 'error', message: 'Room already exists. Choose a different code.' });
+    return;
+  }
+
+  client.roomId = roomId;
+  client.isHost = true;
+  rooms.set(roomId, new Set([client]));
+  send(client, { type: 'created', roomId });
+}
+
+function handleJoinRoom(client, roomIdRaw) {
+  if (!roomIdRaw) {
+    send(client, { type: 'error', message: 'Room code is required.' });
+    return;
+  }
+
+  const roomId = roomIdRaw.toUpperCase();
+  if (!rooms.has(roomId)) {
+    send(client, { type: 'error', message: 'Room not found. Please check the code.' });
+    return;
+  }
+
+  const participants = rooms.get(roomId);
+  if (participants.size >= 2) {
+    send(client, { type: 'error', message: 'Room is full.' });
+    return;
+  }
+
+  client.roomId = roomId;
+  client.isHost = false;
+  participants.add(client);
+
+  send(client, { type: 'joined', roomId });
+
+  if (participants.size === 2) {
+    for (const participant of participants) {
+      send(participant, { type: 'ready', initiator: participant.isHost });
+    }
+  }
+}
+
+function forwardToRoom(client, message) {
+  if (!client.roomId || !rooms.has(client.roomId)) {
+    send(client, { type: 'error', message: 'You are not in a room.' });
+    return;
+  }
+
+  const participants = rooms.get(client.roomId);
+  for (const participant of participants) {
+    if (participant !== client) {
+      send(participant, message);
+    }
+  }
+}
+
+function cleanupClient(client) {
+  const roomId = client.roomId;
+  if (!roomId) {
+    return;
+  }
+
+  const participants = rooms.get(roomId);
+  if (!participants) {
+    client.roomId = null;
+    client.isHost = false;
+    return;
+  }
+
+  participants.delete(client);
+  client.roomId = null;
+  client.isHost = false;
+
+  if (participants.size === 0) {
+    rooms.delete(roomId);
+    return;
+  }
+
+  let hasHost = false;
+  for (const participant of participants) {
+    if (participant.isHost) {
+      hasHost = true;
+      break;
+    }
+  }
+
+  if (!hasHost) {
+    const [newHost] = participants;
+    if (newHost) {
+      newHost.isHost = true;
+    }
+  }
+
+  for (const participant of participants) {
+    send(participant, { type: 'peer-left', roomId, isHost: participant.isHost });
+  }
+}
+
+function send(client, message) {
+  try {
+    const payload = Buffer.from(JSON.stringify(message));
+    const frame = encodeFrame(payload);
+    client.socket.write(frame);
+  } catch (err) {
+    // ignore
+  }
+}
+
+function decodeFrame(buffer) {
+  if (buffer.length < 2) {
+    return null;
+  }
+
+  const firstByte = buffer[0];
+  const secondByte = buffer[1];
+
+  const opcode = firstByte & 0x0f;
+  let payloadLength = secondByte & 0x7f;
+  let offset = 2;
+
+  if (payloadLength === 126) {
+    if (buffer.length < offset + 2) return null;
+    payloadLength = buffer.readUInt16BE(offset);
+    offset += 2;
+  } else if (payloadLength === 127) {
+    if (buffer.length < offset + 8) return null;
+    const highBits = buffer.readUInt32BE(offset);
+    const lowBits = buffer.readUInt32BE(offset + 4);
+    payloadLength = highBits * Math.pow(2, 32) + lowBits;
+    offset += 8;
+  }
+
+  const isMasked = (secondByte & 0x80) === 0x80;
+  let maskingKey;
+  if (isMasked) {
+    if (buffer.length < offset + 4) return null;
+    maskingKey = buffer.slice(offset, offset + 4);
+    offset += 4;
+  }
+
+  if (buffer.length < offset + payloadLength) {
+    return null;
+  }
+
+  let payload;
+  if (isMasked && maskingKey) {
+    payload = Buffer.alloc(payloadLength);
+    for (let i = 0; i < payloadLength; i += 1) {
+      payload[i] = buffer[offset + i] ^ maskingKey[i % 4];
+    }
+  } else {
+    payload = buffer.slice(offset, offset + payloadLength);
+  }
+
+  return {
+    payload,
+    length: offset + payloadLength,
+    opcode
+  };
+}
+
+function encodeFrame(payload) {
+  const payloadLength = payload.length;
+  let frame;
+  if (payloadLength < 126) {
+    frame = Buffer.alloc(2 + payloadLength);
+    frame[1] = payloadLength;
+    payload.copy(frame, 2);
+  } else if (payloadLength < 65536) {
+    frame = Buffer.alloc(4 + payloadLength);
+    frame[1] = 126;
+    frame.writeUInt16BE(payloadLength, 2);
+    payload.copy(frame, 4);
+  } else {
+    frame = Buffer.alloc(10 + payloadLength);
+    frame[1] = 127;
+    // Split 64-bit length into two 32-bit parts
+    frame.writeUInt32BE(Math.floor(payloadLength / Math.pow(2, 32)), 2);
+    frame.writeUInt32BE(payloadLength >>> 0, 6);
+    payload.copy(frame, 10);
+  }
+  frame[0] = 0x81;
+  return frame;
+}
+
+function generateAcceptValue(secWebSocketKey) {
+  return crypto
+    .createHash('sha1')
+    .update(secWebSocketKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'binary')
+    .digest('base64');
+}
+
+function generateRoomCode() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+function getContentType(ext) {
+  switch (ext) {
+    case '.html':
+      return 'text/html';
+    case '.css':
+      return 'text/css';
+    case '.js':
+    case '.jsx':
+      return 'application/javascript';
+    case '.json':
+      return 'application/json';
+    default:
+      return 'text/plain';
+  }
+}
+
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- implement a lightweight Node.js signaling server that supports room codes for two-person WebRTC calls
- add a React front-end (served from CDN) to create, join, and manage calls via WebRTC offer/answer exchange
- style the interface and document setup instructions in the README

## Testing
- node server.js (terminated after verifying startup)


------
https://chatgpt.com/codex/tasks/task_e_68cfba58a0b483279975db1a6c9f81b8