### PR TITLE
feat: replace vite build with esbuild script

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "build": "node ./scripts/build.mjs",
+    "preview": "node ./scripts/preview.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/client/public/vite.svg
+++ b/client/public/vite.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5af0ff" />
+      <stop offset="100%" stop-color="#5f36ff" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#grad)" />
+  <path d="M20 44L30 18h4l10 26h-6l-2.2-6h-8.6L25 44h-5z" fill="#fff" />
+</svg>

--- a/client/scripts/build.mjs
+++ b/client/scripts/build.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { build } from 'esbuild';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const distDir = path.join(projectRoot, 'dist');
+const assetsDir = path.join(distDir, 'assets');
+
+const envPrefix = 'VITE_';
+const mode = process.env.MODE ?? 'production';
+const baseUrl = process.env.BASE_URL ?? '/';
+
+const env = {
+  MODE: mode,
+  DEV: false,
+  PROD: true,
+  SSR: false,
+  BASE_URL: baseUrl,
+};
+
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith(envPrefix)) {
+    env[key] = value ?? '';
+  }
+}
+
+async function ensureCleanDist() {
+  await fs.rm(distDir, { recursive: true, force: true });
+  await fs.mkdir(assetsDir, { recursive: true });
+}
+
+async function copyDir(source, destination) {
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  await fs.mkdir(destination, { recursive: true });
+  for (const entry of entries) {
+    const src = path.join(source, entry.name);
+    const dest = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(src, dest);
+    } else if (entry.isFile()) {
+      await fs.copyFile(src, dest);
+    }
+  }
+}
+
+async function copyPublicDir() {
+  const publicDir = path.join(projectRoot, 'public');
+  try {
+    await fs.access(publicDir);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  await copyDir(publicDir, distDir);
+}
+
+async function writeHtml() {
+  const templatePath = path.join(projectRoot, 'index.html');
+  let html = await fs.readFile(templatePath, 'utf8');
+
+  html = html.replace('/src/main.jsx', './assets/main.js');
+  html = html.replace('href="/vite.svg"', 'href="./vite.svg"');
+
+  const cssPath = path.join(assetsDir, 'main.css');
+  try {
+    await fs.access(cssPath);
+    const cssLinkTag = '    <link rel="stylesheet" href="./assets/main.css" />\n';
+    html = html.replace('</head>', `${cssLinkTag}  </head>`);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  await fs.writeFile(path.join(distDir, 'index.html'), html, 'utf8');
+}
+
+async function run() {
+  await ensureCleanDist();
+
+  await build({
+    entryPoints: [path.join(projectRoot, 'src', 'main.jsx')],
+    outdir: assetsDir,
+    bundle: true,
+    format: 'esm',
+    sourcemap: true,
+    minify: true,
+    splitting: false,
+    target: ['es2019'],
+    logLevel: 'info',
+    loader: {
+      '.js': 'jsx',
+      '.jsx': 'jsx',
+      '.ts': 'ts',
+      '.tsx': 'tsx',
+      '.css': 'css',
+    },
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'import.meta.env': JSON.stringify(env),
+    },
+  });
+
+  await copyPublicDir();
+  await writeHtml();
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/client/scripts/preview.mjs
+++ b/client/scripts/preview.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promises as fs } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const distDir = path.join(projectRoot, 'dist');
+const port = Number(process.env.PORT ?? 4173);
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+};
+
+async function readFileSafe(filePath) {
+  try {
+    const data = await fs.readFile(filePath);
+    return data;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function resolveFile(requestPath) {
+  const cleanPath = decodeURIComponent(requestPath.split('?')[0]);
+  const absolutePath = path.join(distDir, cleanPath);
+
+  try {
+    const stats = await fs.stat(absolutePath);
+    if (stats.isDirectory()) {
+      const indexPath = path.join(absolutePath, 'index.html');
+      const indexContent = await readFileSafe(indexPath);
+      if (indexContent) {
+        return { filePath: indexPath, content: indexContent };
+      }
+    } else if (stats.isFile()) {
+      const content = await readFileSafe(absolutePath);
+      if (content) {
+        return { filePath: absolutePath, content };
+      }
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const fallbackPath = path.join(distDir, 'index.html');
+  const fallbackContent = await readFileSafe(fallbackPath);
+  if (!fallbackContent) {
+    return null;
+  }
+  return { filePath: fallbackPath, content: fallbackContent };
+}
+
+const server = http.createServer(async (req, res) => {
+  const result = await resolveFile(req.url ?? '/');
+  if (!result) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not Found');
+    return;
+  }
+
+  const ext = path.extname(result.filePath);
+  const contentType = mimeTypes[ext] ?? 'application/octet-stream';
+  res.writeHead(200, { 'Content-Type': contentType });
+  res.end(result.content);
+});
+
+server.listen(port, () => {
+  console.log(`Preview server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- replace the client build pipeline with a custom esbuild-based script that writes the production HTML without depending on rollup's native bindings
- add a simple Node-based preview server so `npm run preview` continues to work with the esbuild output
- include a bundled SVG favicon that the build script copies from the client public directory

## Testing
- npm run build *(fails in this container because the cached esbuild package is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd709ff808327bcc2efc91a5aea22